### PR TITLE
Fix shortcode processor

### DIFF
--- a/initializer.php
+++ b/initializer.php
@@ -78,6 +78,8 @@ class SurveyJS_SurveyJS {
     }
 
     function wps_process_shortcode($attrs) {
+        ob_start();
+        
         $id = sanitize_text_field($attrs["id"]);
         $getSurveyJsonUri = add_query_arg(array('action' => 'SurveyJS_GetSurveyJson'), admin_url('admin-ajax.php'));
         $saveResultUri = add_query_arg(array('action' => 'SurveyJS_SaveResult'), admin_url('admin-ajax.php'));
@@ -128,6 +130,8 @@ class SurveyJS_SurveyJS {
             }
         </script>        
         <?php
+                        
+        return ob_get_clean();
     }
   
   }


### PR DESCRIPTION
Without this the survey is injected wherever the post content is retrieved, instead of only where it is displayed. For example when getting `the_excerpt`. For us this was causing a survey to be initialised in the head of the document when a post's excerpt was being used as a document's "description" meta tag, instead of in the body of the document as intended.