### PR TITLE
PR: SurveyJS WordPress - It is possible to upload a PHP file into the SurveyJS WordPress plugin and execute it via File Upload 

### DIFF
--- a/src/trunk/ajax_handlers/upload_files.php
+++ b/src/trunk/ajax_handlers/upload_files.php
@@ -51,10 +51,10 @@ class SurveyJS_UploadFiles extends SurveyJS_AJAX_Handler {
                 
                 $uploadedfile["name"] = $filename;
                 
-                $movefile = upload_user_file( $uploadedfile, $path);
+                // $movefile = upload_user_file( $uploadedfile, $path);
 
-                // $upload_overrides = array( 'test_form' => false );
-                //$movefile = wp_handle_upload( $uploadedfile, $upload_overrides );
+                $upload_overrides = array( 'test_form' => false );
+                $movefile = wp_handle_upload( $uploadedfile, $upload_overrides );
 
                 if ( !$movefile || isset( $movefile['error'] ) ) {
                     wp_send_json( array('error' => $movefile['error']) );


### PR DESCRIPTION
work for the https://github.com/surveyjs/surveyjs-wordpress/issues/55