### PR TITLE
PR: Single-Input Text Fields - Quotes in comment values - “Uncaught SyntaxError: Expected ‘,’ or ‘}’ after property value in JSON at position….“ 

### DIFF
--- a/src/trunk/views/results.php
+++ b/src/trunk/views/results.php
@@ -97,7 +97,7 @@ class SurveyJS_Results {
                 }
 
                 var data = results.map(function(result) {
-                    var replacedResult = decodeHtml(result.json).replace(/\\/g, "");
+                    var replacedResult = decodeHtml(result.json).replace(/\\/g, "").replace(/""/g, "\"");
                     var dataItem = JSON.parse(replacedResult || "{}");
                     dataItem.resultId = result.id;
                     return dataItem;


### PR DESCRIPTION
work for the https://github.com/surveyjs/surveyjs-wordpress/issues/59