### PR TITLE
Add Column Format radiogroup to toggle the headers on the Datatable

### DIFF
--- a/src/trunk/normalize.css
+++ b/src/trunk/normalize.css
@@ -1,100 +1,219 @@
+/* normalize.css content above... */
+
+/* Column format control styles added from results.php */
+#columnFormat {
+  margin-bottom: 10px;
+}
+#columnFormat .column-format-label {
+  min-width: 150px;
+  background-color: transparent;
+  border: 2px solid #1ab394;
+  padding: 6px 12px;
+  border-radius: 5px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  box-sizing: border-box;
+  color: #fff;
+}
+#columnFormat .column-format-label.active {
+  background-color: #1ab394;
+  color: #fff;
+}
+#columnFormat .column-format-label:focus-within {
+  outline: 2px solid rgba(26, 179, 148, 0.25);
+  outline-offset: 2px;
+}
+@media (max-width: 480px) {
+  #columnFormat .column-format-label {
+    min-width: 120px;
+    padding: 6px 8px;
+  }
+}
+
+/* SurveyJS results: column format radiogroup styles */
+.sjs-radiogroup {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  overflow: auto;
+  width: fit-content;
+  margin: 10px;
+  padding: 5px;
+  border: 1px solid #1ab384;
+  border-radius: 5px;
+}
+
+.sjs-radio-option {
+  min-width: 150px;
+  padding: 6px;
+  border: 2px solid #1ab394;
+  border-radius: 5px;
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  background: transparent;
+  color: #1ab394;
+  transition: background-color 0.12s ease, color 0.12s ease,
+    border-color 0.12s ease;
+  text-align: center;
+}
+
+.sjs-radio-input {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.sjs-radio-option.sjs-active {
+  background: #1ab394;
+  color: #fff;
+  border-color: #1ab394;
+}
+
+.sjs-radio-option:focus-within {
+  outline: 3px solid rgba(26, 179, 148, 0.18);
+  outline-offset: 2px;
+}
+
+/* Screen-reader only helpers */
+.sjs-sr-only,
+.sjs-column-format-live {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 #sjs-editor-container .spg-search-editor_input {
-    color: var(--sjs-general-forecolor, var(--foreground, #161616));
-    font-family: var(--sjs-font-family, var(--font-family));
-    font-size: calc(1.5*(var(--sjs-base-unit, var(--base-unit, 8px))));
-    font-style: normal;
-    font-weight: 600;
-    line-height: calc(2*(var(--sjs-base-unit, var(--base-unit, 8px))));
-    border: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    display: block;
-    background: rgba(0,0,0,0);
-    box-sizing: border-box;
-    width: 100%;
-    outline: none;
-    padding-inline-start: var(--sjs-base-unit, var(--base-unit, 8px));
-    padding-inline-end: var(--sjs-base-unit, var(--base-unit, 8px));
+  color: var(--sjs-general-forecolor, var(--foreground, #161616));
+  font-family: var(--sjs-font-family, var(--font-family));
+  font-size: calc(1.5 * (var(--sjs-base-unit, var(--base-unit, 8px))));
+  font-style: normal;
+  font-weight: 600;
+  line-height: calc(2 * (var(--sjs-base-unit, var(--base-unit, 8px))));
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  background: rgba(0, 0, 0, 0);
+  box-sizing: border-box;
+  width: 100%;
+  outline: none;
+  padding-inline-start: var(--sjs-base-unit, var(--base-unit, 8px));
+  padding-inline-end: var(--sjs-base-unit, var(--base-unit, 8px));
 }
 
 #sjs-editor-container .spg-input {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    display: block;
-    background-color: var(--sjs-general-backcolor, var(--background, #fff));
-    box-sizing: border-box;
-    width: 100%;
-    height: calc(6*(var(--sjs-base-unit, var(--base-unit, 8px))));
-    border: none;
-    box-shadow: inset 0 0 0 1px var(--sjs-border-inside, var(--border-inside, rgba(0, 0, 0, 0.16)));
-    padding: calc(1.5*(var(--sjs-base-unit, var(--base-unit, 8px)))) calc(2*(var(--sjs-base-unit, var(--base-unit, 8px))));
-    outline: none;
-    font-size: calc(2*(var(--sjs-base-unit, var(--base-unit, 8px))));
-    font-family: var(--sjs-font-family, var(--font-family));
-    color: var(--sjs-general-forecolor, var(--foreground, #161616));
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  background-color: var(--sjs-general-backcolor, var(--background, #fff));
+  box-sizing: border-box;
+  width: 100%;
+  height: calc(6 * (var(--sjs-base-unit, var(--base-unit, 8px))));
+  border: none;
+  box-shadow: inset 0 0 0 1px
+    var(--sjs-border-inside, var(--border-inside, rgba(0, 0, 0, 0.16)));
+  padding: calc(1.5 * (var(--sjs-base-unit, var(--base-unit, 8px))))
+    calc(2 * (var(--sjs-base-unit, var(--base-unit, 8px))));
+  outline: none;
+  font-size: calc(2 * (var(--sjs-base-unit, var(--base-unit, 8px))));
+  font-family: var(--sjs-font-family, var(--font-family));
+  color: var(--sjs-general-forecolor, var(--foreground, #161616));
 }
 
 #sjs-editor-container .spg-input:focus,
 #sjs-editor-container .spg-input.spg-dropdown:focus,
 #sjs-editor-container .spg-input.spg-dropdown:focus-within,
 #sjs-editor-container .spg-input-container:focus-within {
-  box-shadow: inset 0 0 0 2px var(--sjs-primary-backcolor, var(--primary, #19b394));
+  box-shadow: inset 0 0 0 2px
+    var(--sjs-primary-backcolor, var(--primary, #19b394));
 }
 
 #sjs-editor-container .sd-dropdown__filter-string-input {
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 100%;
-    max-width: 100%;
-    border: none;
-    outline: none;
-    padding: 0;
-    font-family: var(--sjs-font-editorfont-family, var(--sjs-font-family, var(--font-family, var(--sjs-default-font-family))));
-    font-weight: var(--sjs-font-editorfont-weight, 400);
-    color: var(--sjs-font-editorfont-color, var(--sjs-general-forecolor, rgba(0, 0, 0, 0.91)));
-    font-size: var(--sjs-mobile-font-editorfont-size, var(--sjs-font-editorfont-size, var(--sjs-font-size, 16px)));
-    line-height: calc(1.5*(var(--sjs-mobile-font-editorfont-size, var(--sjs-font-editorfont-size, var(--sjs-font-size, 16px)))));
-    background-color: rgba(0,0,0,0);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    display: inline-block;
-    appearance: none;
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 100%;
+  max-width: 100%;
+  border: none;
+  outline: none;
+  padding: 0;
+  font-family: var(
+    --sjs-font-editorfont-family,
+    var(--sjs-font-family, var(--font-family, var(--sjs-default-font-family)))
+  );
+  font-weight: var(--sjs-font-editorfont-weight, 400);
+  color: var(
+    --sjs-font-editorfont-color,
+    var(--sjs-general-forecolor, rgba(0, 0, 0, 0.91))
+  );
+  font-size: var(
+    --sjs-mobile-font-editorfont-size,
+    var(--sjs-font-editorfont-size, var(--sjs-font-size, 16px))
+  );
+  line-height: calc(
+    1.5 *
+      (
+        var(
+          --sjs-mobile-font-editorfont-size,
+          var(--sjs-font-editorfont-size, var(--sjs-font-size, 16px))
+        )
+      )
+  );
+  background-color: rgba(0, 0, 0, 0);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+  appearance: none;
 }
 
 #sjs-editor-container input.disabled,
-#sjs-editor-container input:disabled, 
-#sjs-editor-container select.disabled, 
-#sjs-editor-container select:disabled, 
-#sjs-editor-container textarea.disabled, 
+#sjs-editor-container input:disabled,
+#sjs-editor-container select.disabled,
+#sjs-editor-container select:disabled,
+#sjs-editor-container textarea.disabled,
 #sjs-editor-container textarea:disabled {
-    box-shadow: none;
-  }
-
-
-#sjs-editor-container .spg-input-container__input {
-    flex-grow: 1;
-    width: 100%;
-    padding: var(--sjs-base-unit, var(--base-unit, 8px)) calc(1.5*(var(--sjs-base-unit, var(--base-unit, 8px))));
-    color: var(--sjs-general-forecolor, var(--foreground, #161616));
-    font-size: calc(2*(var(--sjs-base-unit, var(--base-unit, 8px))));
-    font-family: var(--sjs-font-family, var(--font-family));
-    outline: none;
-    border: none;
-    line-height: calc(3*(var(--sjs-base-unit, var(--base-unit, 8px))));
-    background-color: rgba(0, 0, 0, 0);
+  box-shadow: none;
 }
 
-#sjs-editor-container  .spg-input-container {
-    display: flex;
-    justify-content: space-between;
-    cursor: default;
-    padding: calc(0.5*(var(--sjs-base-unit, var(--base-unit, 8px))));
-    align-items: center;
-    gap: calc(0.5*(var(--sjs-base-unit, var(--base-unit, 8px))));
-    box-shadow: 0 0 0 1px inset var(--sjs-border-inside, var(--border-inside, rgba(0, 0, 0, 0.16)));
+#sjs-editor-container .spg-input-container__input {
+  flex-grow: 1;
+  width: 100%;
+  padding: var(--sjs-base-unit, var(--base-unit, 8px))
+    calc(1.5 * (var(--sjs-base-unit, var(--base-unit, 8px))));
+  color: var(--sjs-general-forecolor, var(--foreground, #161616));
+  font-size: calc(2 * (var(--sjs-base-unit, var(--base-unit, 8px))));
+  font-family: var(--sjs-font-family, var(--font-family));
+  outline: none;
+  border: none;
+  line-height: calc(3 * (var(--sjs-base-unit, var(--base-unit, 8px))));
+  background-color: rgba(0, 0, 0, 0);
+}
+
+#sjs-editor-container .spg-input-container {
+  display: flex;
+  justify-content: space-between;
+  cursor: default;
+  padding: calc(0.5 * (var(--sjs-base-unit, var(--base-unit, 8px))));
+  align-items: center;
+  gap: calc(0.5 * (var(--sjs-base-unit, var(--base-unit, 8px))));
+  box-shadow: 0 0 0 1px inset
+    var(--sjs-border-inside, var(--border-inside, rgba(0, 0, 0, 0.16)));
 }

--- a/src/trunk/views/results.php
+++ b/src/trunk/views/results.php
@@ -36,45 +36,66 @@ class SurveyJS_Results {
                             <h3 class="results-header"><?php echo $surveyName; ?> survey results</h3>
                         </div>
                         <div class="sv_body">
+                            <div id="columnFormat" class="sjs-radiogroup" role="radiogroup" aria-label="Column Header Format" aria-describedby="columnFormatHelp">
+                                <div id="columnFormatDescription">
+                                    Column Header Format:
+                                <div id="columnFormatHelp" class="sjs-sr-only">Choose how table column headers are shown: question title or question name.</div>
+                                </div>
+                                <label for="columnFormat-title" class="sjs-radio-option" tabindex="0">
+                                    <input id="columnFormat-title" class="sjs-radio-input" type="radio" name="columnFormat" value="title" checked aria-checked="true">Question Title
+                                </label>
+                                <label for="columnFormat-name" class="sjs-radio-option" tabindex="0">
+                                    <input id="columnFormat-name" class="sjs-radio-input" type="radio" name="columnFormat" value="name" aria-checked="false">Question Name
+                                </label>
+
+                                <div id="columnFormatLive" role="status" aria-live="polite" class="sjs-column-format-live"></div>
+                            </div>
                             <table id="wpSjsResultsTable" class="table table-striped table-bordered"></table>
                         </div>
                     </div>
                 </div>
-                <div id="surveyElement"></div>
-            </div>
-
-            <script>
+                                <div id="surveyElement"></div>
+                        </div>  
+                        <script>
                 var $ = jQuery;
                 var surveyJson = "<?php echo $surveyJson; ?>";
                 var survey = new Survey.Model(JSON.parse(surveyJson));
 
-                var columns = survey.getAllQuestions().map(function(q) {
-                    return {
-                        data: q.name,
-                        sTitle: (q.title || "").trim(" ") || q.name,
-                        mRender: function(data, type, row) {
-                        survey.data = row;
-                        var displayValue = q.displayValue;
-                        return (
-                            (typeof displayValue === "string"
-                            ? displayValue
-                            : JSON.stringify(displayValue)) || ""
-                        );
-                        }
-                    };
-                });
+                var columnFormat = (function() { return ($('input[name="columnFormat"]:checked').val() || 'title'); })();
 
-                columns.push({
-                    targets: -1,
-                    data: null,
-                    sortable: false,
-                    className: "center",
-                    defaultContent:
-                    `
-                     <button id='showInSurvey' style='min-width: 150px; margin-right: 50px; color: white;background-color: #1ab394;border: none;padding: 6px;border-radius: 5px;'>Show in Survey</button>
-                     <button id='deleteResult' style='min-width: 150px; color: white;background-color: #d9534f;border: none;padding: 6px;border-radius: 5px;'>Delete result </button>
-                    `
-                });
+                function createColumns() {
+                    var cols = survey.getAllQuestions().map(function(q) {
+                        return {
+                            data: q.name,
+                            sTitle: (columnFormat === 'title') ? ((q.title || "").trim(" ") || q.name) : q.name,
+                            mRender: function(data, type, row) {
+                                survey.data = row;
+                                var displayValue = q.displayValue;
+                                return (
+                                    (typeof displayValue === "string"
+                                    ? displayValue
+                                    : JSON.stringify(displayValue)) || ""
+                                );
+                            }
+                        };
+                    });
+
+                    cols.push({
+                        targets: -1,
+                        data: null,
+                        sortable: false,
+                        className: "center",
+                        defaultContent:
+                        `
+                         <button id='showInSurvey' style='min-width: 150px; margin-right: 50px; color: white;background-color: #1ab394;border: none;padding: 6px;border-radius: 5px;'>Show in Survey</button>
+                         <button id='deleteResult' style='min-width: 150px; color: white;background-color: #d9534f;border: none;padding: 6px;border-radius: 5px;'>Delete result </button>
+                        `
+                    });
+
+                    return cols;
+                }
+
+                var columns = createColumns();
 
                 // var windowSurvey = new Survey.PopupSurveyModel(surveyJson);
                 // windowSurvey.survey.mode = "display";
@@ -119,13 +140,76 @@ class SurveyJS_Results {
                     return dataItem;
                 });
 
-                var table = $("#wpSjsResultsTable").DataTable({
-                    dom: 'Bfrtip',
-                    buttons: [
-                        'copy', 'csv', 'excel', /*'pdf',*/ 'print'
-                    ],
-                    columns: columns,
-                    data: data
+                var table;
+
+                function initTable() {
+                    table = $("#wpSjsResultsTable").DataTable({
+                        dom: 'Bfrtip',
+                        buttons: [
+                            'copy', 'csv', 'excel', /*'pdf',*/ 'print'
+                        ],
+                        columns: columns,
+                        data: data
+                    });
+                }
+
+                initTable();
+
+                // Initialize aria-checked and active classes on labels
+                function updateAriaAndActive() {
+                    $('#columnFormat input[name="columnFormat"]').each(function() {
+                        var $input = $(this);
+                        var checked = $input.is(':checked');
+                        $input.attr('aria-checked', checked ? 'true' : 'false');
+                        var id = $input.attr('id');
+                        var $label = $('label[for="' + id + '"]');
+                        if (checked) {
+                            $label.addClass('sjs-active');
+                        } else {
+                            $label.removeClass('sjs-active');
+                        }
+                    });
+                }
+
+                updateAriaAndActive();
+
+                var columnFormatChangeTimeout = null;
+                $('#columnFormat input[name="columnFormat"]').on('change', function() {
+                    columnFormat = $(this).val();
+                    updateAriaAndActive();
+
+                    if (columnFormatChangeTimeout) clearTimeout(columnFormatChangeTimeout);
+                    columnFormatChangeTimeout = setTimeout(function() {
+                        // preserve state
+                        var page = table.page();
+                        var order = table.order();
+                        var search = table.search();
+                        var length = table.page.len();
+
+                        try {
+                            table.destroy();
+                        } catch (e) {
+                            // ignore if already destroyed
+                        }
+
+                        columns = createColumns();
+                        initTable();
+
+                        // restore state
+                        table.page.len(length);
+                        table.order(order);
+                        table.search(search);
+                        table.page(page).draw(false);
+
+                        // announce change after reinit
+                        var labelText = $('label[for="columnFormat-' + (columnFormat === 'title' ? 'title' : 'name') + '"]').text().trim();
+                        var $live = $('#columnFormatLive');
+                        // force re-announcement
+                        $live.text('');
+                        setTimeout(function() {
+                            $live.text('Column header format set to ' + labelText + '.');
+                        }, 50);
+                    }, 200);
                 });
 
                 $('#wpSjsResultsTable tbody').on('click', '#deleteResult', function (e) {


### PR DESCRIPTION
## Rationale:

Surveys often have considerable post-processing logic requiring data-munging and computation from additional data science tooling. Using the question titles as headers can make munging cumbersome when attempting to identify columns. The ability to select whether to use the Question Title or the Question Name for the header can make munging easier.

## Implementation:

- Add a toggle in the survey export settings to choose between using Question Titles or Question Names as headers.
- Default to using Question Titles for backward compatibility.
- Re-draw the datatable to reflect the selected header option when toggled.

<img width="516" height="154" alt="Screenshot" src="https://github.com/user-attachments/assets/1688dbea-63f0-4175-8d08-158ce56113ab" />


### Known Issues:

Redrawing the datatable causes the modal typically shown when "Show in Survey" is pressed, to pop up. I'm unsure why this is happening, but it does not affect functionality. If anyone has insights on preventing this, please share or ask to modify my PR!
